### PR TITLE
fix: export the emoji type

### DIFF
--- a/emoji.ts
+++ b/emoji.ts
@@ -4,6 +4,8 @@ import type { Emoji } from "./types.ts";
 import emojis from "./all.json" assert { type: "json" };
 import { reUnicode } from "./unicode.ts";
 
+export { Emoji };
+
 // Regex to parse emoji in a string - e.g. :coffee:
 const reEmojiName = /:([a-zA-Z0-9_\-\+]+):/g;
 


### PR DESCRIPTION
I missed this one; it is only exported from `types.ts`.  Probably best to re-export.
